### PR TITLE
Update watchify to 3.9.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "require-dir": "^0.3.0",
     "run-sequence": "^1.0.2",
     "vinyl-source-stream": "^1.1.0",
-    "watchify": "^2.4.0"
+    "watchify": "^3.9.0"
   },
   "dependencies": {
     "adaro": "^0.1.7",


### PR DESCRIPTION
This removes a dependency on an old version of `fsevents` which can cause crashes with Node v7.