### PR TITLE
Remove anon-stats.eff.org tracking code.

### DIFF
--- a/server/templates/components/piwik.dust
+++ b/server/templates/components/piwik.dust
@@ -1,8 +1,2 @@
 <div id="anon-stats">
-  <noscript>
-    <img src="https://anon-stats.eff.org/js/?idsite=21&amp;rec=1" style="border:0" alt="" />
-  </noscript>
-  <script>
-    document.getElementById('anon-stats').innerHTML = '<img src="https://anon-stats.eff.org/js/?idsite=21&amp;rec=1&amp;urlref='+encodeURIComponent(document.referrer)+'&amp;action_name='+encodeURIComponent(document.title)+'" style="border:0" alt="" />';
-  </script>
 </div>


### PR DESCRIPTION
EFF no longer needs to track democracy.io page views. Thanks :)